### PR TITLE
Add support for reporting build version.

### DIFF
--- a/Wavefront.SDK.CSharp.Test/UtilsTest.cs
+++ b/Wavefront.SDK.CSharp.Test/UtilsTest.cs
@@ -404,5 +404,27 @@ namespace Wavefront.SDK.CSharp.Test
                         "}\n", actual);
 #endif
         }
+
+        [Fact]
+        public void TestBuildVersion()
+        {
+            Assert.Equal(0.0D, Utils.GetSemVer(""));
+
+            Assert.Equal(1.0100D, Utils.GetSemVer("1.1.0"));
+
+            Assert.Equal(1.0100D, Utils.GetSemVer("1.1.0-SNAPSHOT"));
+
+            Assert.Equal(1.0101D, Utils.GetSemVer("1.1.1"));
+
+            Assert.Equal(1.1001D, Utils.GetSemVer("1.10.1"));
+
+            Assert.Equal(1.0110D, Utils.GetSemVer("1.1.10"));
+
+            Assert.Equal(1.0001D, Utils.GetSemVer("1.0.1"));
+
+            Assert.Equal(1.0010D, Utils.GetSemVer("1.0.10"));
+
+            Assert.Equal(1.1010D, Utils.GetSemVer("1.10.10"));
+        }
     }
 }

--- a/Wavefront.SDK.CSharp/Common/Constants.cs
+++ b/Wavefront.SDK.CSharp/Common/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Wavefront.SDK.CSharp.Common
+﻿using System.Text.RegularExpressions;
+
+namespace Wavefront.SDK.CSharp.Common
 {
     /// <summary>
     /// Class to define all sdk constants
@@ -100,5 +102,11 @@
         /// by Wavefront instrumentation.
         /// </summary>
         public const string WavefrontIgnoreHeader = "X-WF-IGNORE";
+
+        /// <summary>
+        /// Semantic version matcher regex.
+        /// </summary>
+        public static readonly Regex SemverRegex =
+            new Regex("([0-9]\\d*)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9]+))?");
     }
 }

--- a/Wavefront.SDK.CSharp/DirectIngestion/WavefrontDirectIngestionClient.cs
+++ b/Wavefront.SDK.CSharp/DirectIngestion/WavefrontDirectIngestionClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Timers;
@@ -182,6 +183,8 @@ namespace Wavefront.SDK.CSharp.DirectIngestion
                         .Build();
                 }
 
+                double sdkVersion = Utils.GetSemVer(Assembly.GetExecutingAssembly());
+                client.sdkMetricsRegistry.Gauge("version", () => sdkVersion);
                 client.sdkMetricsRegistry.Gauge("points.queue.size",
                     () => client.metricsBuffer.Count);
                 client.sdkMetricsRegistry.Gauge("points.queue.remaining_capacity",

--- a/Wavefront.SDK.CSharp/Proxy/WavefrontProxyClient.cs
+++ b/Wavefront.SDK.CSharp/Proxy/WavefrontProxyClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Timers;
 using Microsoft.Extensions.Logging;
@@ -213,6 +214,9 @@ namespace Wavefront.SDK.CSharp.Proxy
                 client.timer = new Timer(flushIntervalSeconds * 1000);
                 client.timer.Elapsed += client.Run;
                 client.timer.Enabled = true;
+
+                double sdkVersion = Utils.GetSemVer(Assembly.GetExecutingAssembly());
+                client.sdkMetricsRegistry.Gauge("version", () => sdkVersion);
 
                 client.pointsDiscarded = client.sdkMetricsRegistry.Counter("points.discarded");
                 client.pointsValid = client.sdkMetricsRegistry.Counter("points.valid");

--- a/Wavefront.SDK.CSharp/Wavefront.SDK.CSharp.csproj
+++ b/Wavefront.SDK.CSharp/Wavefront.SDK.CSharp.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU1701</NoWarn>
     <PackageId>Wavefront.SDK.CSharp</PackageId>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Title>Wavefront by VMware SDK for C#</Title>
     <Authors>Wavefront</Authors>
     <Description>This package provides support for sending metrics, histograms and opentracing spans to Wavefront via proxy or direct ingestion.</Description>


### PR DESCRIPTION
Also verified Tier 2 and above can utilize this by passing in Executing Assembly like: Utils.GetSemVer(Assembly.GetExecutingAssembly()): 
